### PR TITLE
Don't require views to be in module "views"

### DIFF
--- a/src/oscar/apps/dashboard/nav.py
+++ b/src/oscar/apps/dashboard/nav.py
@@ -86,7 +86,7 @@ def default_access_fn(user, url_name, url_args=None, url_kwargs=None):
     # label that can be loaded by get_class (e.g.
     # 'dashboard.catalogue.app), which then essentially checks
     # INSTALLED_APPS for the right module to load
-    match = re.search('(dashboard[\w\.]*)\.views$', view_module)
+    match = re.search('(dashboard[\w\.]*)\.\w*$', view_module)
     if not match:
         raise exception
     app_label_str = match.groups()[0] + '.app'


### PR DESCRIPTION
There is no need to only allow views to reside in a module named "views". This arbitrary restriction impedes proper content-related separation of concerns in our application code.

The change is modifying the effects of the `default_access_fn`, whose purpose is to determine whether a user has the right to access a given page (given as `url_name`, for example `'dashboard:settlement-list'`) and if the link to that page should therefore be shown in the navigation bar or not.

In order to determine that, the function tries to find the `app` responsible for the view and finally get the permissions (`app_instance.get_permissions(view_name)`). The `view_name` is the latter part of the `url_name` given above, so in my example `settlement-list`.

So the missing information is the name of the application holding that permission information. When following the _standard oscar layout_, the views reside in `apps.dashboard.invoices.settlement_list.views` and the name of the app we want to load is `dashboard.invoices.settlement_list.app`, so we only have to strip the `apps` prefix and replace `.views` with `.app`. That is exactly what the regular expression `'(dashboard[\w\.]*)\.views$'` does.

So, if we now want to slightly modify the _standard oscar layout_ and get rid of the assumption that all views have to reside in the `.views` module, we can modify the regexp above to also except other module names: `'(dashboard[\w\.]*)\.\w*$'`. `\w+$` accepts any non-empty sequence of alphanumeric characters instead of `views` at the last part of the view module name. For the sake of completeness, the definition of `\w` from the [Python docs](https://docs.python.org/2/library/re.html):

> When the LOCALE and UNICODE flags are not specified, matches any alphanumeric character and the underscore; this is equivalent to the set [a-zA-Z0-9_]. With LOCALE, it will match the set [0-9_] plus whatever characters are defined as alphanumeric for the current locale.  > If UNICODE is set, this will match the characters [0-9_] plus whatever is classified as alphanumeric in the Unicode character properties database.

Using this change, we can get rid of the workarounds like [this](https://github.com/machtfit/machtfit-oscar/blob/develop/apps/dashboard/invoices/views.py#L31) and directly load views from e.g. `settlement_list.py`.

I don't think there are any negative side effects of this change, cause we still follow the rest of the _standard oscar layout_ and as long as the views and the `app.py` are in the same parent module the correct permissions will be found. The permissions itself are not effected in any way.